### PR TITLE
Address potential infinite rebuild loop

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
-  mode: 'jit',
+  // mode: 'jit', // Appears to cause infinite rebuild of common.css in some cases, re-enable for potential performance improvements
   purge: ['./common.css', './challenges/**/*.{js,ts,html}'],
   theme: {
     colors: {


### PR DESCRIPTION
Disable Tailwind's JIT to avoid potential infinite rebuild of common.css.

Platform where I experienced the issue:

macOS: 11.6
arch: x86_64
node: 14.17.0
npm: 6.14.13
editor: VS Code 1.61.1
terminal: zsh 5.8 (default) running inside VS Code
machine: MBP 15" 2018